### PR TITLE
new method to login to vk.com

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -11,6 +11,7 @@ import random
 import requests
 import hashlib
 import cookielib
+import vkAuth
 h = HTMLParser.HTMLParser()
 
 import SimpleDownloader as downloader
@@ -46,32 +47,12 @@ def Main_menu():
 		if selfAddon.getSetting('vk_token')!=default_vk_token:
 			selfAddon.setSetting('vk_token',default_vk_token)
 	else:
-		try:
-			#login in vk.com - login in account
-			cookies = cookielib.CookieJar()
-			opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies))
-			response = opener.open('https://login.vk.com/?act=login&email='+selfAddon.getSetting('vk_email')+'&pass='+selfAddon.getSetting('vk_password')+'&expire=&vk=')
-			#login in vk.com - get the token
-			request2=urllib2.Request('https://oauth.vk.com/authorize?client_id=2648691&scope=audio,offline&redirect_uri=http://oauth.vk.com/blank.html&display=touch&response_type=token')
-			cookies.add_cookie_header(request2)
-			response2 = opener.open(request2)
-			selfAddon.setSetting('vk_token',re.search('access_token=(.+?)&', response2.geturl()).group(1))
-			notification(translate(30861),translate(30865),'4000',addonfolder+artfolder+'notif_vk.png')
-		except:
-			try:
-				#if the previous step fail, maybe is necessary give permissions to the application (if used by 1st time), lets try...
-				request2=urllib2.Request(re.search('<form method="post" action="(.+?)">', response2.read()).group(1),{})
-				request2.add_header('Referer', 'https://oauth.vk.com/authorize?client_id=2648691&scope=audio,offline&redirect_uri=http://oauth.vk.com/blank.html&display=touch&response_type=token')
-				cookies.add_cookie_header(request2)
-				response2 = opener.open(request2)
-				selfAddon.setSetting('vk_token',re.search('access_token=(.+?)&', response2.geturl()).group(1))
-				notification(translate(30861),translate(30865),'4000',addonfolder+artfolder+'notif_vk.png')
-			except:
-				#if the previous step fail, the account provided is invalid
-				dialog = xbmcgui.Dialog()
-				ok = dialog.ok(translate(30400),translate(30867))
-				xbmcaddon.Addon(addon_id).openSettings()
-				return
+		#login in vk.com - get the token
+		email = selfAddon.getSetting('vk_email')
+		passw = selfAddon.getSetting('vk_password')
+		token = vkAuth.getToken(email, passw, 2648691, 'audio,offline')
+		selfAddon.setSetting('vk_token',token)
+		notification(translate(30861),translate(30865),'4000',addonfolder+artfolder+'notif_vk.png')
 	#check if token is valid
 	codigo_fonte = abrir_url('https://api.vk.com/method/audio.search.json?q=eminem&access_token='+selfAddon.getSetting("vk_token"))
 	decoded_data = json.loads(codigo_fonte)

--- a/vkAuth.py
+++ b/vkAuth.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+# 2015 Techdealer
+
+##############LIBRARIES TO IMPORT AND SETTINGS####################
+
+import urllib,urllib2,re
+from HTMLParser import HTMLParser
+import cookielib
+
+
+
+###################################################################################
+#Token Parser
+
+class TokenParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.url = None
+        self.params = {}
+        self.in_form = False
+        self.form_parsed = False
+        self.method = "GET"
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        if tag == "form":
+            if self.form_parsed:
+                raise RuntimeError("Second form on page")
+            if self.in_form:
+                raise RuntimeError("Already in form")
+            self.in_form = True 
+        if not self.in_form:
+            return
+        attrs = dict((name.lower(), value) for name, value in attrs)
+        if tag == "form":
+            self.url = attrs["action"] 
+            if "method" in attrs:
+                self.method = attrs["method"]
+        elif tag == "input" and "type" in attrs and "name" in attrs:
+            if attrs["type"] in ["hidden", "text", "password"]:
+                self.params[attrs["name"]] = attrs["value"] if "value" in attrs else ""
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        if tag == "form":
+            if not self.in_form:
+                raise RuntimeError("Unexpected end of <form>")
+            self.in_form = False
+            self.form_parsed = True
+
+
+
+
+###################################################################################
+#Login to vk.com
+
+def getToken(email, password, client_id, scope):
+    opener = urllib2.build_opener(
+                                  urllib2.HTTPCookieProcessor(cookielib.CookieJar()),
+                                  urllib2.HTTPRedirectHandler())
+    response = opener.open(
+                           "http://oauth.vk.com/oauth/authorize?" + \
+                           "redirect_uri=http://oauth.vk.com/blank.html&response_type=token&" + \
+                           "client_id=%s&scope=%s&display=wap" % (client_id, scope)
+                           )
+    parser = TokenParser()
+    parser.feed(response.read())
+    parser.params["email"] = email
+    parser.params["pass"] = password
+    response = opener.open(parser.url, urllib.urlencode(parser.params))
+    try:
+        return re.search('access_token=(.+?)&', response.geturl()).group(1)
+    except:
+        #if the previous step fail, maybe is necessary give permissions to the application (if used by 1st time), lets try...
+        parser = TokenParser()
+        parser.feed(response.read())
+        response = opener.open(parser.url, urllib.urlencode(parser.params))
+        return re.search('access_token=(.+?)&', response.geturl()).group(1)


### PR DESCRIPTION
I had the problem that I couldn't use my vk.com account. Every time I started the add-on it said that my credentials are wrong. But they weren't (I checked that more than once).
So I debugged the script and found out that the failure was in these lines:
```python
#login in vk.com - login in account
cookies = cookielib.CookieJar()
opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies))
response = opener.open('https://login.vk.com/?act=login&email='+selfAddon.getSetting('vk_email')+'&pass='+selfAddon.getSetting('vk_password')+'&expire=&vk=')
#login in vk.com - get the token
request2=urllib2.Request('https://oauth.vk.com/authorize?client_id=2648691&scope=audio,offline&redirect_uri=http://oauth.vk.com/blank.html&display=touch&response_type=token')
cookies.add_cookie_header(request2)
response2 = opener.open(request2)
selfAddon.setSetting('vk_token',re.search('access_token=(.+?)&', response2.geturl()).group(1))
notification(translate(30861),translate(30865),'4000',addonfolder+artfolder+'notif_vk.png')
```

I don't know what exactly went wrong, but this login method didn't work for me. After a little research I found a method which works for me. I mainly took it from this site: http://habrahabr.ru/post/143972/ and adapted it to the add-on.
I don't know if this problem affects other users, but if so, you can implement my solution to your add-on.